### PR TITLE
`show-open-prs-of-forks` only include related PRs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7572,9 +7572,9 @@
 			}
 		},
 		"github-url-detection": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-1.0.0.tgz",
-			"integrity": "sha512-xtbyN8FNQStN3kuW3wGRJvtBfRLeNVoMtwJfA7wy8d09zDauiXlcObSBEpGKWRdMIG+gF6Hs24OAL4KuUoAhCg=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-1.1.2.tgz",
+			"integrity": "sha512-AQ8IXCiJfrRU9nHbeWLLVFkKE2S1OdOrXcfQT9yHxR+L3WPDk6LZEzO8trXV+3XEpkbw3xfw0UR/83ksQjWAHA=="
 		},
 		"glob": {
 			"version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"element-ready": "^4.1.1",
 		"fit-textarea": "^2.0.0",
 		"github-reserved-names": "^1.1.8",
-		"github-url-detection": "^1.0.0",
+		"github-url-detection": "^1.1.2",
 		"image-promise": "^7.0.0",
 		"indent-textarea": "^2.0.1",
 		"linkify-issues": "2.0.0-nolookbehind",

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -73,7 +73,7 @@ async function initHeadHint(): Promise<void | false> {
 
 async function initDeleteHint(): Promise<void | false> {
 	const [count, url] = await getPRs();
-	if (!count || !location.pathname.endsWith('settings')) {
+	if (!count) {
 		return false;
 	}
 
@@ -102,7 +102,8 @@ features.add({
 		pageDetect.isRepoSettings
 	],
 	exclude: [
-		() => !pageDetect.isForkedRepo()
+		() => !pageDetect.isForkedRepo(),
+		() => !location.pathname.endsWith('settings')
 	],
 	waitForDomReady: false,
 	init: initDeleteHint

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -6,35 +6,38 @@ import * as pageDetect from 'github-url-detection';
 
 import * as api from '../libs/api';
 import features from '../libs/features';
-import {getForkedRepo, getUsername, pluralize} from '../libs/utils';
+import {getForkedRepo, getUsername, pluralize, getRepoURL} from '../libs/utils';
 
 function getLinkCopy(count: number): string {
 	return pluralize(count, 'one open pull request', '$$ open pull requests');
 }
 
 const countPRs = cache.function(async (forkedRepo: string): Promise<[number, number?]> => {
-	// Grab the PR count and the first PR's URL
-	// This allows to link to the PR directly if only one is found
 	const {search} = await api.v4(`
 		search(
-			first: 1,
+			first: 100,
 			type: ISSUE,
 			query: "repo:${forkedRepo} is:pr is:open author:${getUsername()}"
 		) {
-			issueCount
 			nodes {
 				... on PullRequest {
 					number
+					headRepository {
+						nameWithOwner
+					}
 				}
 			}
 		}
 	`);
 
-	if (search.issueCount === 1) {
-		return [1, search.nodes[0].number];
+	const prs = search.nodes.filter((pr: AnyObject) => pr.headRepository.nameWithOwner.toLowerCase() === getRepoURL());
+
+	// If only one is found, pass the pr number so we can link to the PR directly
+	if (prs.length === 1) {
+		return [1, prs[0].number];
 	}
 
-	return [search.issueCount];
+	return [prs.length];
 }, {
 	maxAge: 1 / 2, // Stale after 12 hours
 	staleWhileRevalidate: 2,

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -99,11 +99,10 @@ features.add({
 	init: initHeadHint
 }, {
 	include: [
-		pageDetect.isRepoSettings
+		pageDetect.isRepoMainSettings
 	],
 	exclude: [
-		() => !pageDetect.isForkedRepo(),
-		() => !location.pathname.endsWith('settings')
+		() => !pageDetect.isForkedRepo()
 	],
 	waitForDomReady: false,
 	init: initDeleteHint

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -30,9 +30,10 @@ const countPRs = cache.function(async (forkedRepo: string): Promise<[number, num
 		}
 	`);
 
+	// Only show PRs originated from the current repo
 	const prs = search.nodes.filter((pr: AnyObject) => pr.headRepository.nameWithOwner.toLowerCase() === getRepoURL());
 
-	// If only one is found, pass the pr number so we can link to the PR directly
+	// If only one is found, pass the PR number so we can link to the PR directly
 	if (prs.length === 1) {
 		return [1, prs[0].number];
 	}

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -72,7 +72,7 @@ async function initHeadHint(): Promise<void | false> {
 
 async function initDeleteHint(): Promise<void | false> {
 	const [count, url] = await getPRs();
-	if (!count) {
+	if (!count || !location.pathname.endsWith('settings')) {
 		return false;
 	}
 


### PR DESCRIPTION
@loilo could you send this PR? (I dont know if the types are correct, double check it)

it should fix the issue of `show-open-prs-of-forks` includes unrelated PRs



<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
